### PR TITLE
Let the plugin template depend on version 1.7 of Ready! API

### DIFF
--- a/ready-api-plugin-template/pom.xml
+++ b/ready-api-plugin-template/pom.xml
@@ -27,8 +27,13 @@
         </dependency>
         <dependency>
             <groupId>com.smartbear</groupId>
+            <artifactId>ready-api-core</artifactId>
+            <version>1.7.0</version>
+        </dependency>
+        <dependency>
+            <groupId>com.smartbear</groupId>
             <artifactId>ready-api-soapui-pro</artifactId>
-            <version>1.0.0</version>
+            <version>1.7.0</version>
         </dependency>
         <dependency>
             <groupId>com.smartbear</groupId>
@@ -37,6 +42,18 @@
         </dependency>
 
     </dependencies>
+<build>
+    <plugins>
+        <plugin>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <configuration>
+                <source>1.7</source>
+                <target>1.7</target>
+            </configuration>
+        </plugin>
+    </plugins>
+</build>
+
 
 
 </project>

--- a/ready-api-plugin-template/src/main/java/com/smartbear/ready/plugin/template/factories/SampleDiscoveryMethod.java
+++ b/ready-api-plugin-template/src/main/java/com/smartbear/ready/plugin/template/factories/SampleDiscoveryMethod.java
@@ -27,7 +27,7 @@ public class SampleDiscoveryMethod implements DiscoveryMethod {
 
     @Override
     public String getDescription() {
-        return null;
+        return "Dummy Discovery method - doesn't actually do anything.";
     }
 
     @Override

--- a/ready-api-plugin-template/src/main/java/com/smartbear/ready/plugin/template/factories/SampleDiscoveryMethod.java
+++ b/ready-api-plugin-template/src/main/java/com/smartbear/ready/plugin/template/factories/SampleDiscoveryMethod.java
@@ -26,6 +26,11 @@ public class SampleDiscoveryMethod implements DiscoveryMethod {
     }
 
     @Override
+    public String getDescription() {
+        return null;
+    }
+
+    @Override
     public String getLabel() {
         return "Ghost Discovery!";
     }

--- a/ready-api-plugin-template/src/main/java/com/smartbear/ready/plugin/template/factories/SampleRequestTransport.java
+++ b/ready-api-plugin-template/src/main/java/com/smartbear/ready/plugin/template/factories/SampleRequestTransport.java
@@ -12,6 +12,7 @@ import com.eviware.soapui.model.util.BaseResponse;
 import com.eviware.soapui.plugins.auto.PluginRequestTransport;
 import com.eviware.soapui.support.UISupport;
 
+import java.io.UnsupportedEncodingException;
 import java.net.URL;
 
 /**
@@ -76,6 +77,15 @@ public class SampleRequestTransport implements RequestTransport {
         @Override
         public URL getURL() {
             return null;
+        }
+
+        @Override
+        public byte[] getRawResponseBody() {
+            try {
+                return responseContent == null ? new byte[0] : responseContent.getBytes("UTF-8");
+            } catch (UnsupportedEncodingException wontHappen) {
+                return new byte[0];
+            }
         }
 
         @Override


### PR DESCRIPTION
Some additions to interfaces had to be accommodated, and we need a dependency to ready-api-core to get the net.sf.json library in.
