### PR TITLE
Update unreachable Eviware repository URL to the working SmartBear Software repository URL

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,8 +16,8 @@
     <repositories>
         <repository>
             <id>eviware</id>
-            <name>Eviware Maven2 Repository</name>
-            <url>http://www.eviware.com/repository/maven2</url>
+            <name>SmartBear Software Maven2 Repository</name>
+            <url>http://smartbearsoftware.com/repository/maven2</url>
         </repository>
         <repository>
             <id>central</id>

--- a/ready-api-plugin-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/ready-api-plugin-archetype/src/main/resources/archetype-resources/pom.xml
@@ -9,8 +9,8 @@
     <repositories>
         <repository>
             <id>eviware</id>
-            <name>Eviware Maven2 Repository</name>
-            <url>http://www.eviware.com/repository/maven2</url>
+            <name>SmartBear Software Maven2 Repository</name>
+            <url>http://smartbearsoftware.com/repository/maven2</url>
         </repository>
         <repository>
             <id>central</id>


### PR DESCRIPTION
I have found that the current Eviware repository URL is unreachable and not working. But I've found a new working SmartBear Software repository URL on [README page](https://github.com/SmartBear/ready-api-plugins/tree/master/ready-api-plugin-archetype) of `ready-api-plugin-archetype` package. So here is the update.